### PR TITLE
Allow passing plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,16 +13,19 @@ module.exports = function (options) {
 				'sourcemap' in opts ? opts.sourcemap : // Rollup options
 					opts.sourceMap !== false; // Old style Rollup options
 			Object.assign(options, {
-				parser: {
-					plugins: {
+				parser: Object.assign({}, options.parser || {}, {
+					plugins: Object.assign({}, options.parser && options.parser.plugins || {}, {
 						dynamicImport: true
-					},
+					}),
 					onParserInstallation(acorn) {
+						if (options.onParserInstallation) {
+							options.onParserInstallation(acorn);
+						}
 						// Patch acorn to support dynamic import
 						// eslint-disable-next-line import/no-extraneous-dependencies
 						require('acorn-dynamic-import/lib/inject').default(acorn);
 					}
-				}
+				})
 			});
 		},
 		transform(code, id) {


### PR DESCRIPTION
Support for passing plugins to Nodent was broken in [this commit](https://github.com/oligot/rollup-plugin-nodent/commit/18017ade9d0d537be83edcdaeb762bdf304fe1f1).